### PR TITLE
Better tests

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -1,0 +1,32 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', '.github/workflows/cov.yml' ]
+  push:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', '.github/workflows/cov.yml' ]
+    tags: '*'
+  workflow_dispatch:
+
+jobs:
+  determine-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup latest Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install pip --upgrade
+        pip install .[dev]
+    - name: Test with pytest and create coverage report
+      run: pytest --cov=unfolding_linear --cov-report=xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
+  push:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
+    tags: '*'
+
+jobs:
+  run-tests:
+    name: Python ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['3.8', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup latest Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.version }}
+    - name: Install dependencies
+      run: |
+        pip install pip --upgrade
+        pip install .[dev]
+    - name: Test with pytest
+      run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.12']
+        version: ['3.9', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Clone repository

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Python](https://img.shields.io/pypi/pyversions/tensorflow.svg?style=plastic)](https://pypi.org/project/unfolding-linear/) [![PyPI](https://badge.fury.io/py/unfolding-linear.svg)](https://pypi.org/project/unfolding-linear/)
+[![Tests](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml/badge.svg)](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml)
+[![docs](https://img.shields.io/badge/docs-click_here-blue.svg)](https://Salahberra2022.github.io/deep_unfolding/)
+[![PyPI](https://img.shields.io/pypi/v/unfolding-linear)](https://pypi.org/project/unfolding-linear/)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/unfolding-linear?color=blueviolet)
+[![GPLv3](https://img.shields.io/badge/license-GPLv3-yellowgreen.svg)](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3)
 
 # unfolding-linear: Deep unfolding of iterative methods
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Tests](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml/badge.svg)](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/Salahberra2022/deep_unfolding/branch/main/graph/badge.svg?token=UPDATEME)](https://codecov.io/gh/Salahberra2022/deep_unfolding)
 [![docs](https://img.shields.io/badge/docs-click_here-blue.svg)](https://Salahberra2022.github.io/deep_unfolding/)
 [![PyPI](https://img.shields.io/pypi/v/unfolding-linear)](https://pypi.org/project/unfolding-linear/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/unfolding-linear?color=blueviolet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "unfolding_linear"
 description = "Deep unfolding of iterative methods to solve linear equations"
 version = "0.1.0"
 authors = [
-    { name = "Salah Berra", email = "salahberra39@gmail.com"},
-    { name = "Nennouche Mohamed", email = "moohaameed.nennouche@gmail.com"},
+    { name = "Salah Berra", email = "salahberra39@gmail.com" },
+    { name = "Nennouche Mohamed", email = "moohaameed.nennouche@gmail.com" },
     { name = "Nuno Fachada", email = "nuno.fachada@ulusofona.pt" }
 ]
 readme = "README.md"
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering"
 ]
-dependencies = [ "numpy >= 1.26", "torch>=2.3" ]
+dependencies = [ "numpy >= 1.26", "torch >= 2.3" ]
 
 [project.urls]
 "Homepage" = "https://github.com/Salahberra2022/deep_unfolding"

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -3,8 +3,10 @@
 import pytest
 import torch
 import numpy as np
-from unfolding_linear.methods import model_iterations, base_model, GS, RI, Jacobi, SOR, SOR_CHEBY, AOR, AOR_CHEBY
-from unfolding_linear.utils import device, decompose_matrix  # Assurez-vous que les utilitaires nécessaires sont importés correctement
+from unfolding_linear import (
+    model_iterations, base_model, GS, RI, Jacobi, SOR, SOR_CHEBY, AOR, AOR_CHEBY,
+    device, decompose_matrix
+)
 
 @pytest.fixture
 def generate_matrices():
@@ -25,11 +27,11 @@ def generate_solution():
 def test_model_iterations(generate_matrices, generate_solution):
     n, _, _, bs, _ = generate_matrices
     solution = generate_solution
-    
+
     class DummyModel:
         def iterate(self, i):
             return solution, []
-    
+
     model = DummyModel()
     s_hats, norm_list_model = model_iterations(model, solution, n, total_itr=5, bs=bs)
 
@@ -41,7 +43,7 @@ def test_model_iterations(generate_matrices, generate_solution):
 def test_base_model_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     model = base_model(n, A, H, bs, y)
-    
+
     assert model.n == n, "Attribute n should be initialized correctly"
     assert model.H.shape == H.shape, "Attribute H should be initialized correctly"
     assert model.bs == bs, "Attribute bs should be initialized correctly"
@@ -58,7 +60,7 @@ def test_base_model_initialization(generate_matrices):
 def test_GS_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     gs_model = GS(n, A, H, bs, y)
-    
+
     assert gs_model.n == n, "Attribute n should be initialized correctly in GS model"
     assert gs_model.H.shape == H.shape, "Attribute H should be initialized correctly in GS model"
     assert gs_model.bs == bs, "Attribute bs should be initialized correctly in GS model"
@@ -75,9 +77,9 @@ def test_GS_initialization(generate_matrices):
 def test_GS_iterate(generate_matrices):
     n, A, H, bs, y = generate_matrices
     gs_model = GS(n, A, H, bs, y)
-    
+
     s, traj = gs_model.iterate(num_itr=5)
-    
+
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert traj[0].shape == (bs, n), "Each element in the trajectory should have shape (bs, n)"
     assert s.shape == (bs, n), "Final solution tensor should have shape (bs, n)"
@@ -85,7 +87,7 @@ def test_GS_iterate(generate_matrices):
 def test_RI_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     ri_model = RI(n, A, H, bs, y)
-    
+
     assert ri_model.n == n, "Attribute n should be initialized correctly in RI model"
     assert ri_model.H.shape == H.shape, "Attribute H should be initialized correctly in RI model"
     assert ri_model.bs == bs, "Attribute bs should be initialized correctly in RI model"
@@ -102,7 +104,7 @@ def test_RI_initialization(generate_matrices):
 def test_RI_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     ri_model = RI(n, A, H, bs, y)
-    
+
     s, traj = ri_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -110,7 +112,7 @@ def test_RI_iteration(generate_matrices):
 def test_Jacobi_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     jacobi_model = Jacobi(n, A, H, bs, y, omega=0.2)
-    
+
     assert jacobi_model.n == n, "Attribute n should be initialized correctly in Jacobi model"
     assert jacobi_model.H.shape == H.shape, "Attribute H should be initialized correctly in Jacobi model"
     assert jacobi_model.bs == bs, "Attribute bs should be initialized correctly in Jacobi model"
@@ -128,7 +130,7 @@ def test_Jacobi_initialization(generate_matrices):
 def test_Jacobi_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     jacobi_model = Jacobi(n, A, H, bs, y, omega=0.2)
-    
+
     s, traj = jacobi_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -136,7 +138,7 @@ def test_Jacobi_iteration(generate_matrices):
 def test_SOR_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_model = SOR(n, A, H, bs, y, omega=1.8)
-    
+
     assert sor_model.n == n, "Attribute n should be initialized correctly in SOR model"
     assert sor_model.H.shape == H.shape, "Attribute H should be initialized correctly in SOR model"
     assert sor_model.bs == bs, "Attribute bs should be initialized correctly in SOR model"
@@ -154,7 +156,7 @@ def test_SOR_initialization(generate_matrices):
 def test_SOR_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_model = SOR(n, A, H, bs, y, omega=1.8)
-    
+
     s, traj = sor_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -162,7 +164,7 @@ def test_SOR_iteration(generate_matrices):
 def test_SOR_CHEBY_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_cheby_model = SOR_CHEBY(n, A, H, bs, y, omega=1.8, omegaa=0.8, gamma=0.8)
-    
+
     assert sor_cheby_model.n == n, "Attribute n should be initialized correctly in SOR_CHEBY model"
     assert sor_cheby_model.H.shape == H.shape, "Attribute H should be initialized correctly in SOR_CHEBY model"
     assert sor_cheby_model.bs == bs, "Attribute bs should be initialized correctly in SOR_CHEBY model"
@@ -182,7 +184,7 @@ def test_SOR_CHEBY_initialization(generate_matrices):
 def test_SOR_CHEBY_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_cheby_model = SOR_CHEBY(n, A, H, bs, y, omega=1.8, omegaa=0.8, gamma=0.8)
-    
+
     s, traj = sor_cheby_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -190,7 +192,7 @@ def test_SOR_CHEBY_iteration(generate_matrices):
 def test_AOR_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_model = AOR(n, A, H, bs, y, omega=0.3, r=0.2)
-    
+
     assert aor_model.n == n, "Attribute n should be initialized correctly in AOR model"
     assert aor_model.H.shape == H.shape, "Attribute H should be initialized correctly in AOR model"
     assert aor_model.bs == bs, "Attribute bs should be initialized correctly in AOR model"
@@ -209,7 +211,7 @@ def test_AOR_initialization(generate_matrices):
 def test_AOR_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_model = AOR(n, A, H, bs, y, omega=0.3, r=0.2)
-    
+
     s, traj = aor_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -217,7 +219,7 @@ def test_AOR_iteration(generate_matrices):
 def test_AOR_CHEBY_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_cheby_model = AOR_CHEBY(n, A, H, bs, y, omega=0.1, r=0.1)
-    
+
     assert aor_cheby_model.n == n, "Attribute n should be initialized correctly in AOR_CHEBY model"
     assert aor_cheby_model.H.shape == H.shape, "Attribute H should be initialized correctly in AOR_CHEBY model"
     assert aor_cheby_model.bs == bs, "Attribute bs should be initialized correctly in AOR_CHEBY model"
@@ -236,7 +238,7 @@ def test_AOR_CHEBY_initialization(generate_matrices):
 def test_AOR_CHEBY_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_cheby_model = AOR_CHEBY(n, A, H, bs, y, omega=0.1, r=0.1)
-    
+
     s, traj = aor_cheby_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"

--- a/tests/test_train_methods.py
+++ b/tests/test_train_methods.py
@@ -1,8 +1,10 @@
 import pytest
 import torch
 import torch.nn as nn
-from unfolding_linear.train_methods import train_model, evaluate_model, SORNet, SOR_CHEBY_Net, AORNet, RINet 
-from unfolding_linear.utils import device, generate_A_H_sol  
+from unfolding_linear import (
+    train_model, evaluate_model, SORNet, SOR_CHEBY_Net, AORNet, RINet,
+    device, generate_A_H_sol
+)
 
 # Fixture pour générer les matrices et tensors nécessaires
 @pytest.fixture
@@ -16,7 +18,7 @@ def generate_matrices():
 def test_SORNet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -30,9 +32,9 @@ def test_SORNet_initialization(generate_matrices):
 def test_SORNet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -42,7 +44,7 @@ def test_SOR_CHEBY_Net_initialization(generate_matrices):
     num_itr = 25
     A, H, y, n, m, bs, solution = generate_matrices
     model = SOR_CHEBY_Net(num_itr, A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -61,9 +63,9 @@ def test_SOR_CHEBY_Net_forward(generate_matrices):
     num_itr = 3
     A, H, y, n, m, bs, solution = generate_matrices
     model = SOR_CHEBY_Net(num_itr, A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=num_itr)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == num_itr + 1, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -73,7 +75,7 @@ def test_SOR_CHEBY_Net_forward(generate_matrices):
 def test_AORNet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = AORNet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -88,9 +90,9 @@ def test_AORNet_initialization(generate_matrices):
 def test_AORNet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = AORNet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -99,7 +101,7 @@ def test_AORNet_forward(generate_matrices):
 def test_RINet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = RINet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -113,9 +115,9 @@ def test_RINet_initialization(generate_matrices):
 def test_RINet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = RINet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -130,16 +132,16 @@ def test_train_model(generate_matrices):
     loss_func = nn.MSELoss()
 
     trained_model, loss_gen = train_model(model, optimizer, loss_func, solution, total_itr=3, num_batch=5)
-    
+
     assert isinstance(trained_model, SORNet), "Returned model should be of type SORNet"
     assert len(loss_gen) == 3, "Length of loss_gen should be equal to total_itr"
 
 def test_evaluate_model(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     norm_list = evaluate_model(model, solution, n, bs=bs, total_itr=3, device=device)
-    
+
     assert len(norm_list) == 4, "Length of norm_list should be equal to total_itr + 1"
     assert all(isinstance(err, float) for err in norm_list), "All elements in norm_list should be floats"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unfolding_linear.utils import generate_A_H_sol, decompose_matrix
+from unfolding_linear import generate_A_H_sol, decompose_matrix
 import pytest
 import torch
 import numpy as np


### PR DESCRIPTION
This pull request makes the following changes:

- Tests run automatically (in GitHub) on each push in Windows, Linux and MacOS and Python 3.9 and Python 3.12
- Tests coverage is automatically measured and sent to CodeCov (see note below)
- Update `README.md` badges to show test results, test coverage, number of PyPI downloads, docs link, etc.

For CodeCov code coverage to work, the repository will need to be public. After that create a free account on [CodeCov](https://app.codecov.io/login) (login with GitHub credentials) and setup the `Salahberra2022/deep_unfolding` repo. After the next push or pull request merge to the repository, the coverage report is uploaded to CodeCov.

Then one can update the CodeCov badge in `README.md` as follows: in CodeCov, go to `Salahberra2022/deep_unfolding`, then Settings, then Badges & Graphs, then copy-paste the Markdown badge code and replace the current one in the `README.md`. I can also do this afterwards, no worries. You only need to create the CodeCov account and setup the `Salahberra2022/deep_unfolding` repo there.