### PR TITLE
Add CI PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on:
+  push:
+    tags: 'v*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout package
+        uses: actions/checkout@v4
+      - name: Install build and publish dependencies
+        run: |
+          pip3 install --upgrade build
+      - name: Build package
+        run: |
+          python3 -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
With this pull request, each time a new release / version is made on GitHub (and the project version in `pyproject.toml` is properly updated), the project is automatically published on PyPI. For this to work, it's necessary to create an account / project token in PyPI, copy this value, and then set it in the GitHub repo as the `PYPI_API_TOKEN` variable:

![image](https://github.com/Salahberra2022/deep_unfolding/assets/3018963/0bcd8995-b844-49c6-b511-084d12a7a952)


